### PR TITLE
Fix user logout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Learnforge Lms" %></title>
+    <title><%= content_for(:title) || "LearnForge LMS" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="Learnforge Lms">
+    <meta name="application-name" content="LearnForge LMS">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
     <% end %>
 
     <% if session[:user_id] %>
-      <%= link_to "Log out", logout_path, method: :delete %>
+      <%= button_to "Log out", logout_path, method: :delete %>
     <% end %>
     <%= yield %>
   </body>

--- a/spec/system/user_login_spec.rb
+++ b/spec/system/user_login_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "User Login", type: :system do
     fill_in "Password", with: "password"
     click_button "Sign In"
 
-    click_link "Log out"
+    click_button "Log out"
 
     expect(page).to have_current_path(new_session_path)
     expect(page).to have_content("Logged out successfully!")


### PR DESCRIPTION
The user logout functionality was not working because it was using a link acts as a GET request instead of a DELETE. Using a button fixes this.